### PR TITLE
Add orientation and NIfTI utility tests

### DIFF
--- a/tests/testthat/test-nifti-utils.R
+++ b/tests/testthat/test-nifti-utils.R
@@ -1,0 +1,19 @@
+context("nifti utils")
+
+library(neuroim2)
+
+# verify helper functions for nifti metadata
+
+test_that("internal nifti helpers return expected values", {
+  expect_equal(neuroim2:::.getDataCode("FLOAT"), 16)
+  expect_equal(neuroim2:::.getDataSize("DOUBLE"), 8)
+  expect_equal(neuroim2:::.getDataStorage(8), "INT")
+  expect_equal(neuroim2:::.niftiExt("nifti-gz"), list(header="nii.gz", data="nii.gz"))
+})
+
+# check error handling
+
+test_that("nifti helper functions throw errors on invalid input", {
+  expect_error(neuroim2:::.getDataCode("FOO"))
+  expect_error(neuroim2:::.niftiExt("bogus"))
+})

--- a/tests/testthat/test-orientation.R
+++ b/tests/testthat/test-orientation.R
@@ -1,0 +1,23 @@
+context("orientation")
+
+library(neuroim2)
+
+# Test findAnatomy3D with explicit axis abbreviations
+
+test_that("findAnatomy3D returns the expected orientation", {
+  orient <- findAnatomy3D("L", "P", "I")
+  expect_true(inherits(orient, "AxisSet3D"))
+  expect_identical(orient@i, LEFT_RIGHT)
+  expect_identical(orient@j, POST_ANT)
+  expect_identical(orient@k, INF_SUP)
+})
+
+# Test findAnatomy on a simple permutation matrix
+
+test_that("findAnatomy recovers orientation from identity matrix", {
+  pmat <- diag(3)
+  orient <- findAnatomy(pmat)
+  expect_identical(orient@i, LEFT_RIGHT)
+  expect_identical(orient@j, POST_ANT)
+  expect_identical(orient@k, INF_SUP)
+})


### PR DESCRIPTION
## Summary
- add orientation-related unit tests
- add tests for NIfTI helper functions

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68445d6d10b8832db73756e8dc2c549b