### PR TITLE
Add example for reading NIfTI header

### DIFF
--- a/R/meta_info.R
+++ b/R/meta_info.R
@@ -454,7 +454,9 @@ AFNIMetaInfo <- function(descriptor, afni_header) {
 #' @param file_name the name of the file to read
 #' @return an instance of class \code{\linkS4class{FileMetaInfo}}
 #' @examples
-#' header <- read_header(system.file("extdata", "global_mask_v4.nii", package="neuroim2"))
+#' hdr <- read_header(system.file("extdata", "global_mask_v4.nii", package = "neuroim2"))
+#' dim(hdr)                  # image dimensions
+#' hdr@header$pixdim[5]      # TR in seconds
 #' @export read_header
 read_header <- function(file_name) {
   desc <- find_descriptor(file_name)


### PR DESCRIPTION
## Summary
- expand `read_header` docs with sample code to show how to read just the header
  and inspect dimensions and TR from the NIfTI header

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6854212b7578832d87bbc9be3058b05c