### PR TITLE
Fix plot_overlay orientation and NA-thresholding bugs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # neuroim2 0.12.0
 
+## Bug Fixes
+
+* `plot_overlay()` no longer renders the overlay flipped relative to the background. Previously the overlay was drawn via `grid::rasterGrob`, which ignored the slice's affine transform, so voxel `(1,1)` was placed at the top-left of the panel while the background placed it at its true world (mm) position. Overlays are now reoriented to match the background and span the full pixel-edge extent.
+* `plot_overlay()` no longer errors with "NAs are not allowed in subscripted assignments" when the overlay contains `NA` voxels and `ov_thresh > 0`.
+* `plot_overlay()` panel titles now use `x = `, `y = `, or `z = ` based on the slicing axis (`along`).
+
 ## New Features
 
 * `NeuroVec` now supports optional per-volume `volume_labels()` metadata across dense, sparse, mapped, file-backed, bigvec, and `NeuroVecSeq` backends.

--- a/R/plot-helpers.R
+++ b/R/plot-helpers.R
@@ -161,6 +161,70 @@ matrix_to_raster_grob <- function(mat, cmap = "grays", limits = NULL, alpha = 1,
   grid::rasterGrob(rgba, interpolate = FALSE)
 }
 
+#' Reorient a slice matrix so rasterGrob places voxels at their world location
+#'
+#' `grid::rasterGrob` renders row 1 of a matrix at the top of the destination
+#' region and column 1 at the left, independently of any affine transform, while
+#' ggplot2 places pixels at their true world (mm) position. Without reorienting,
+#' an overlay rasterGrob is flipped / mirrored relative to a background plotted
+#' in world coordinates whenever the slice's transform flips an in-plane axis.
+#'
+#' Given a 2D NeuroSlice and a matching matrix, returns the matrix rearranged so
+#' that voxel `(i, j)` is rendered at its world location, together with a
+#' pixel-edge extent (`xmin/xmax/ymin/ymax`) suitable for `annotation_custom`.
+#' Assumes the in-plane axes map to world axes via flips only (no rotation).
+#'
+#' @keywords internal
+#' @noRd
+orient_slice_for_raster <- function(sl, mat) {
+  nr <- nrow(mat); nc <- ncol(mat)
+  sp <- space(sl)
+
+  idx_11 <- 1L
+  idx_N1 <- as.integer(max(nr, 1L))
+  idx_1N <- as.integer((max(nc, 1L) - 1L) * max(nr, 1L) + 1L)
+  idx_NN <- as.integer(max(nr * nc, 1L))
+
+  c_11 <- as.numeric(index_to_coord(sp, idx_11))
+  c_N1 <- as.numeric(index_to_coord(sp, idx_N1))
+  c_1N <- as.numeric(index_to_coord(sp, idx_1N))
+  c_NN <- as.numeric(index_to_coord(sp, idx_NN))
+
+  d1 <- c_N1 - c_11
+  d2 <- c_1N - c_11
+
+  axis1_is_world_x <- abs(d1[1]) >= abs(d1[2])
+
+  m <- mat
+  if (axis1_is_world_x) {
+    if (d1[1] < 0) m <- m[nr:1, , drop = FALSE]
+    if (d2[2] < 0) m <- m[, nc:1, drop = FALSE]
+    m <- t(m)
+    m <- m[nrow(m):1, , drop = FALSE]
+  } else {
+    if (d1[2] < 0) m <- m[nr:1, , drop = FALSE]
+    if (d2[1] < 0) m <- m[, nc:1, drop = FALSE]
+    m <- m[nrow(m):1, , drop = FALSE]
+  }
+
+  sp_sl <- spacing(sl)
+  if (axis1_is_world_x) {
+    sp_x <- sp_sl[1]; sp_y <- sp_sl[2]
+  } else {
+    sp_x <- sp_sl[2]; sp_y <- sp_sl[1]
+  }
+
+  all_x <- c(c_11[1], c_N1[1], c_1N[1], c_NN[1])
+  all_y <- c(c_11[2], c_N1[2], c_1N[2], c_NN[2])
+  list(
+    mat  = m,
+    xmin = min(all_x) - sp_x / 2,
+    xmax = max(all_x) + sp_x / 2,
+    ymin = min(all_y) - sp_y / 2,
+    ymax = max(all_y) + sp_y / 2
+  )
+}
+
 #' Coordinate helper: fixed aspect and reversed y for radiological convention
 #' @keywords internal
 #' @noRd

--- a/R/plot-overlay.R
+++ b/R/plot-overlay.R
@@ -50,35 +50,45 @@ plot_overlay <- function(
     mov <- slice_to_matrix(sl_ov)
     if (ov_alpha_mode == "proportional") {
       abs_mov <- abs(mov)
-      max_abs <- max(abs_mov, na.rm = TRUE)
+      max_abs <- suppressWarnings(max(abs_mov, na.rm = TRUE))
       if (is.finite(max_abs) && max_abs > 0) {
         amap <- abs_mov / max_abs
       } else {
         amap <- matrix(0, nrow = nrow(mov), ncol = ncol(mov))
       }
       if (isTRUE(ov_thresh > 0)) {
-        amap[abs_mov < ov_thresh] <- 0
+        below <- !is.na(abs_mov) & abs_mov < ov_thresh
+        amap[below] <- 0
       }
       amap[is.na(amap)] <- 0
-      ov_lim <- compute_limits(as.numeric(mov[is.finite(mov)]), mode = ov_range, probs = probs)
-      g_ov <- matrix_to_raster_grob(mov, cmap = ov_cmap, limits = ov_lim,
-                                     alpha = ov_alpha, alpha_map = amap)
-    } else {
-      if (isTRUE(ov_thresh > 0)) mov[abs(mov) < ov_thresh] <- NA_real_
       ov_lim <- compute_limits(as.numeric(mov), mode = ov_range, probs = probs)
-      g_ov <- matrix_to_raster_grob(mov, cmap = ov_cmap, limits = ov_lim, alpha = ov_alpha)
+      ov_o   <- orient_slice_for_raster(sl_ov, mov)
+      amap_o <- orient_slice_for_raster(sl_ov, amap)$mat
+      g_ov <- matrix_to_raster_grob(ov_o$mat, cmap = ov_cmap, limits = ov_lim,
+                                     alpha = ov_alpha, alpha_map = amap_o)
+    } else {
+      if (isTRUE(ov_thresh > 0)) {
+        below <- !is.na(mov) & abs(mov) < ov_thresh
+        mov[below] <- NA_real_
+      }
+      ov_lim <- compute_limits(as.numeric(mov), mode = ov_range, probs = probs)
+      ov_o <- orient_slice_for_raster(sl_ov, mov)
+      g_ov <- matrix_to_raster_grob(ov_o$mat, cmap = ov_cmap, limits = ov_lim, alpha = ov_alpha)
     }
 
-    xr <- range(df_bg$x, na.rm = TRUE)
-    yr <- range(df_bg$y, na.rm = TRUE)
+    slice_label <- switch(as.character(along), "1" = "x", "2" = "y", "3" = "z")
 
     p <- ggplot2::ggplot(df_bg, ggplot2::aes(x, y, fill = value)) +
       ggplot2::geom_raster(interpolate = FALSE) +
       scale_fill_neuro(cmap = bg_cmap, limits = bg_lim) +
       ggplot2::coord_fixed() +
       theme_neuro() +
-      ggplot2::labs(title = paste0("z = ", z)) +
-      ggplot2::annotation_custom(g_ov, xmin = xr[1], xmax = xr[2], ymin = yr[1], ymax = yr[2])
+      ggplot2::labs(title = paste0(slice_label, " = ", z)) +
+      ggplot2::annotation_custom(
+        g_ov,
+        xmin = ov_o$xmin, xmax = ov_o$xmax,
+        ymin = ov_o$ymin, ymax = ov_o$ymax
+      )
 
     p
   }

--- a/tests/testthat/test-plot-overlay-alpha.R
+++ b/tests/testthat/test-plot-overlay-alpha.R
@@ -35,6 +35,75 @@ test_that("matrix_to_raster_grob accepts per-pixel alpha maps", {
   )
 })
 
+test_that("orient_slice_for_raster places voxel (1,1) at bottom-left for identity transform", {
+  sp  <- neuroim2::NeuroSpace(c(4, 5, 2))
+  vol <- neuroim2::NeuroVol(array(0, dim = c(4, 5, 2)), sp)
+  sl  <- neuroim2::slice(vol, 1, along = 3)
+
+  # Marker at voxel (1,1): world coords (0.5, 0.5) → lower-left of ggplot panel
+  mat <- matrix(0, nrow = 4, ncol = 5)
+  mat[1, 1] <- 1
+  # Second marker at voxel (4, 5): upper-right
+  mat[4, 5] <- 2
+
+  out <- neuroim2:::orient_slice_for_raster(sl, mat)
+  # rasterGrob renders row 1 at TOP, col 1 at LEFT.
+  # voxel (1,1) is lower-left, so it should be at out$mat[nrow, 1]
+  expect_equal(out$mat[nrow(out$mat), 1], 1)
+  # voxel (4,5) is upper-right, so out$mat[1, ncol]
+  expect_equal(out$mat[1, ncol(out$mat)], 2)
+  # Extent spans pixel edges: (0, dim) since spacing=1 and origin=0
+  expect_equal(out$xmin, 0)
+  expect_equal(out$xmax, 4)
+  expect_equal(out$ymin, 0)
+  expect_equal(out$ymax, 5)
+})
+
+test_that("orient_slice_for_raster handles flipped x-axis (radiological LPI-like)", {
+  # Build a space where voxel i increases as world x DECREASES (x flipped)
+  trans <- diag(c(-1, 1, 1, 1))
+  trans[1, 4] <- 3     # so voxel (1,1) -> world (3 - 0.5, 0.5) = (2.5, 0.5)
+  sp  <- neuroim2::NeuroSpace(c(4, 5, 2), trans = trans)
+  vol <- neuroim2::NeuroVol(array(0, dim = c(4, 5, 2)), sp)
+  sl  <- neuroim2::slice(vol, 1, along = 3)
+
+  mat <- matrix(0, nrow = 4, ncol = 5)
+  mat[1, 1] <- 1   # voxel (1,1) -> world (2.5, 0.5) = RIGHT-bottom due to flip
+  mat[4, 5] <- 2   # voxel (4,5) -> world (-0.5, 4.5) = LEFT-top
+
+  out <- neuroim2:::orient_slice_for_raster(sl, mat)
+  # voxel (1,1) is bottom-right -> oriented matrix [nrow, ncol]
+  expect_equal(out$mat[nrow(out$mat), ncol(out$mat)], 1)
+  # voxel (4,5) is top-left -> oriented matrix [1, 1]
+  expect_equal(out$mat[1, 1], 2)
+})
+
+test_that("plot_overlay tolerates NAs in overlay with ov_thresh > 0", {
+  sp <- neuroim2::NeuroSpace(c(5, 5, 3))
+  bg <- neuroim2::NeuroVol(array(0, dim = c(5, 5, 3)), sp)
+  ov_arr <- array(stats::rnorm(5 * 5 * 3), dim = c(5, 5, 3))
+  ov_arr[1, 1, 1] <- NA_real_
+  ov_arr[2, 2, 2] <- NA_real_
+  ov <- neuroim2::NeuroVol(ov_arr, sp)
+
+  tf <- tempfile(fileext = ".png")
+  grDevices::png(tf)
+  on.exit({ grDevices::dev.off(); unlink(tf) }, add = TRUE)
+
+  expect_silent(
+    neuroim2::plot_overlay(
+      bgvol = bg, overlay = ov, zlevels = c(1, 2), along = 3,
+      ov_thresh = 0.5, ncol = 2
+    )
+  )
+  expect_silent(
+    neuroim2::plot_overlay(
+      bgvol = bg, overlay = ov, zlevels = c(1, 2), along = 3,
+      ov_alpha_mode = "proportional", ov_thresh = 0.5, ncol = 2
+    )
+  )
+})
+
 test_that("plot_overlay supports ov_alpha_mode='proportional'", {
   sp <- neuroim2::NeuroSpace(c(6, 6, 4))
   bg <- neuroim2::NeuroVol(array(0, dim = c(6, 6, 4)), sp)


### PR DESCRIPTION
plot_overlay drew the background in world (mm) coordinates via geom_raster
but placed the overlay as a grid::rasterGrob stretched to the background's
center-to-center range. rasterGrob renders row 1 of the overlay matrix at
the top of the destination region regardless of the slice's affine, so the
overlay was vertically flipped (and potentially mirrored along x) relative
to the background for any volume whose transform flips an in-plane axis.

Add an internal orient_slice_for_raster() helper that reshapes the overlay
matrix so voxel (i,j) lands at its true world location and returns the
pixel-edge extent for annotation_custom. Drive the overlay and alpha-map
rasters through that helper.

Also:
- NA-safe thresholding: avoid "NAs are not allowed in subscripted
  assignments" when the overlay has NA voxels and ov_thresh > 0.
- Panel titles now use 'x = ', 'y = ', or 'z = ' based on `along`.

Tests cover orient_slice_for_raster for identity and x-flipped transforms
and guard plot_overlay against NA-valued overlays.

Note: the overlay-binary / overlay-proportional vdiffr snapshots capture
the old (buggy) placement and will need to be regenerated.

https://claude.ai/code/session_019s1iKcnmdPT3wKaiqSCLeq